### PR TITLE
multi stage docker build, semver tagging

### DIFF
--- a/.github/workflows/build-buster.yml
+++ b/.github/workflows/build-buster.yml
@@ -2,8 +2,9 @@ name: Buster Build
 
 on:
   push:
-    branches:
-        - main
+    branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 
@@ -14,6 +15,51 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Lowercase repo owner
+        id: repo_owner
+        run: echo "::set-output name=lowercase::$(echo ${{ github.repository_owner }} | tr \"[:upper:]\" \"[:lower:]\")"
+        shell: bash
+
+      - name: Meta for base
+        id: meta_base
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/base
+          tags: |
+            type=raw,value=buster
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Meta for indy_node
+        id: meta_indy_node
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/indy_node
+          # Note: latest will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
+          tags: |
+            type=raw,value=buster
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=IDunion Indy Node Container
+            org.opencontainers.image.description=IDunion Indy Node Container based on python:3.6-slim-buster
+            org.opencontainers.image.vendor=IDunion
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1
@@ -27,13 +73,32 @@ jobs:
         with:
           file: build/Dockerfile.base.buster
           context: ./build
-          tags: idunion/indy-node-container/base:buster
+          push: false
+          tags: ${{ steps.meta_base.outputs.tags }}
+          labels: ${{ steps.meta_base.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
 
       - name: build and push indy node based on buster
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: build/Dockerfile.buster
           context: ./build
-          # TODO: see https://github.com/marketplace/actions/docker-metadata-action
-          tags: idunion/indy-node-container/indy_node:buster,idunion/indy-node-container/indy_node:latest
-          build-args: BASE=ghcr.io/idunion/indy-node-container/base:buster
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_indy_node.outputs.tags }}
+          labels: ${{ steps.meta_indy_node.outputs.labels }}
+          build-args: |
+            BUILDER_BASE=ghcr.io/idunion/indy-node-container/base:buster
+            BASE=python:3.6-slim-buster
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build-ubuntu18.yml
+++ b/.github/workflows/build-ubuntu18.yml
@@ -2,8 +2,9 @@ name: Ubuntu 18 Build
 
 on:
   push:
-    branches:
-        - main
+    branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 
@@ -14,6 +15,51 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Lowercase repo owner
+        id: repo_owner
+        run: echo "::set-output name=lowercase::$(echo ${{ github.repository_owner }} | tr \"[:upper:]\" \"[:lower:]\")"
+        shell: bash
+
+      - name: Meta for base
+        id: meta_base
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/base
+          tags: |
+            type=raw,value=ubuntu
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Meta for indy_node
+        id: meta_indy_node
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/indy_node
+          # Note: latest will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
+          tags: |
+            type=raw,value=ubuntu
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=IDunion Indy Node Container
+            org.opencontainers.image.description=IDunion Indy Node Container based on ubuntu:18.04
+            org.opencontainers.image.vendor=IDunion
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1
@@ -27,12 +73,31 @@ jobs:
         with:
           file: build/Dockerfile.base.ubuntu18
           context: ./build
-          tags: idunion/indy-node-container/base:ubuntu18
+          push: false
+          tags: ${{ steps.meta_base.outputs.tags }}
+          labels: ${{ steps.meta_base.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
 
       - name: build and push indy node based on ubuntu18
         uses: docker/build-push-action@v2
         with:
-          file: build/Dockerfile
+          file: build/Dockerfile.ubuntu18
           context: ./build
-          tags: idunion/indy-node-container/indy_node:ubuntu18
-          build-args: BASE=ghcr.io/idunion/indy-node-container/base:ubuntu18
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_indy_node.outputs.tags }}
+          labels: ${{ steps.meta_indy_node.outputs.labels }}
+          build-args: |
+            BUILDER_BASE=ghcr.io/idunion/indy-node-container/base:ubuntu18
+            BASE=ubuntu:18.04
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ etc_indy/indy.env
 .node.env
 .history
 test/lib_indy
+run/etc_indy/indy.env
+run/lib_indy/sandbox*
+trivy-reports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+all: buster ubuntu
+
+buster_base:
+	docker build -f "build/Dockerfile.base.buster" -t indy-node-container/base:buster build
+
+buster: buster_base
+	docker build -f "build/Dockerfile.buster" -t indy-node-container/indy_node:buster --build-arg BASE=python:3.6-slim-buster --build-arg BUILDER_BASE=indy-node-container/base:buster build
+
+ubuntu_base:
+	docker build -f "build/Dockerfile.base.ubuntu18" -t indy-node-container/base:ubuntu build
+
+ubuntu: ubuntu_base
+	docker build -f "build/Dockerfile.ubuntu18" -t indy-node-container/indy_node:ubuntu --build-arg BASE=ubuntu:18.04 --build-arg BUILDER_BASE=indy-node-container/base:ubuntu build
+
+clean_buster_base:
+	-docker image rm indy-node-container/base:buster
+
+clean_buster:
+	-docker image rm indy-node-container/indy_node:buster
+
+clean_ubuntu_base:
+	-docker image rm indy-node-container/base:ubuntu
+
+clean_ubuntu:
+	-docker image rm indy-node-container/indy_node:ubuntu
+
+clean: clean_buster clean_buster_base clean_ubuntu clean_ubuntu_base
+
+
+# all check targets require a local trivy installation - see https://aquasecurity.github.io/trivy/
+
+check_buster:
+	mkdir -p trivy-reports
+	-trivy image --format template --template "@trivy/html.tpl" -o trivy-reports/buster.html indy-node-container/indy_node:buster
+#	-xdg-open trivy-reports/buster.html
+	-trivy image --severity HIGH,CRITICAL indy-node-container/indy_node:buster
+
+check_ubuntu:
+	mkdir -p trivy-reports
+	-trivy image --format template --template "@trivy/html.tpl" -o trivy-reports/ubuntu.html indy-node-container/indy_node:ubuntu
+#	-xdg-open trivy-reports/ubuntu.html
+	-trivy image --severity HIGH,CRITICAL indy-node-container/indy_node:ubuntu

--- a/build/Dockerfile.buster
+++ b/build/Dockerfile.buster
@@ -1,0 +1,41 @@
+# This container is to run indy-node.
+# It has been created in the indy-node docker working group of the ID Union project.
+# author: Sebastian Schmittner <sebastian.schmittner@eecc.de>
+# author: Guido Wischrop <guido.wischrop@mgm-tp.com>
+# version: 1.1+2021-06-02
+
+ARG BUILDER_BASE=indy-node-container/base:buster
+ARG BASE=python:3.6-slim-buster
+
+FROM $BUILDER_BASE AS builder
+
+# deprecated dependencies based on libssl1.0 / libiny-crypto
+RUN \
+    # for old libssl needed for libindy-crypto
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 && \
+    add-apt-repository "deb http://security.ubuntu.com/ubuntu bionic-security main" && \
+    # for libindy-crypto
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 && \
+    add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" && \
+    apt-get update && \
+    apt-get install -y libssl1.0.0 libindy-crypto=0.4.5 python3-indy-crypto=0.4.5
+
+RUN pip install python3-indy indy-node==1.12.4 indy-plenum==1.12.4
+
+FROM $BASE
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+            libsodium23 \
+            librocksdb5.17 && \
+    apt-get autoremove -y
+
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/lib/libindy* /usr/lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl* /usr/lib/x86_64-linux-gnu/libcrypto* /usr/lib/x86_64-linux-gnu/
+
+COPY init_and_run.sh ./
+
+CMD ["./init_and_run.sh"]

--- a/build/Dockerfile.ubuntu18
+++ b/build/Dockerfile.ubuntu18
@@ -1,0 +1,44 @@
+# This container is to run indy-node.
+# It has been created in the indy-node docker working group of the ID Union project.
+# author: Sebastian Schmittner <sebastian.schmittner@eecc.de>
+# author: Guido Wischrop <guido.wischrop@mgm-tp.com>
+# version: 1.1+2021-06-02
+
+ARG BUILDER_BASE=indy-node-container/base:ubuntu
+ARG BASE=ubuntu:18.04
+
+FROM $BUILDER_BASE AS builder
+
+# deprecated dependencies based on libssl1.0 / libiny-crypto
+RUN \
+    # for old libssl needed for libindy-crypto
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 && \
+    add-apt-repository "deb http://security.ubuntu.com/ubuntu bionic-security main" && \
+    # for libindy-crypto
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 && \
+    add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" && \
+    apt-get update && \
+    apt-get install -y libssl1.0.0 libindy-crypto=0.4.5 python3-indy-crypto=0.4.5
+
+RUN pip install python3-indy indy-node==1.12.4 indy-plenum==1.12.4
+
+FROM $BASE
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+            python3.6 \
+            python3-pip \
+            libsodium23 \
+            librocksdb5.8 \
+    && \
+    apt-get autoremove -y
+
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/lib/libindy* /usr/lib/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl* /usr/lib/x86_64-linux-gnu/libcrypto* /usr/lib/x86_64-linux-gnu/
+
+COPY init_and_run.sh ./
+
+CMD ["./init_and_run.sh"]

--- a/trivy/html.tpl
+++ b/trivy/html.tpl
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+{{- if . }}
+    <style>
+      * {
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      h1 {
+        text-align: center;
+      }
+      .group-header th {
+        font-size: 200%;
+      }
+      .sub-header th {
+        font-size: 150%;
+      }
+      table, th, td {
+        border: 1px solid black;
+        border-collapse: collapse;
+        white-space: nowrap;
+        padding: .3em;
+      }
+      table {
+        margin: 0 auto;
+      }
+      .severity {
+        text-align: center;
+        font-weight: bold;
+        color: #fafafa;
+      }
+      .severity-LOW .severity { background-color: #5fbb31; }
+      .severity-MEDIUM .severity { background-color: #e9c600; }
+      .severity-HIGH .severity { background-color: #ff8800; }
+      .severity-CRITICAL .severity { background-color: #e40000; }
+      .severity-UNKNOWN .severity { background-color: #747474; }
+      .severity-LOW { background-color: #5fbb3160; }
+      .severity-MEDIUM { background-color: #e9c60060; }
+      .severity-HIGH { background-color: #ff880060; }
+      .severity-CRITICAL { background-color: #e4000060; }
+      .severity-UNKNOWN { background-color: #74747460; }
+      table tr td:first-of-type {
+        font-weight: bold;
+      }
+      .links a,
+      .links[data-more-links=on] a {
+        display: block;
+      }
+      .links[data-more-links=off] a:nth-of-type(1n+5) {
+        display: none;
+      }
+      a.toggle-more-links { cursor: pointer; }
+    </style>
+    <title>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ getCurrentTime }}</title>
+    <script>
+      window.onload = function() {
+        document.querySelectorAll('td.links').forEach(function(linkCell) {
+          var links = [].concat.apply([], linkCell.querySelectorAll('a'));
+          [].sort.apply(links, function(a, b) {
+            return a.href > b.href ? 1 : -1;
+          });
+          links.forEach(function(link, idx) {
+            if (links.length > 3 && 3 === idx) {
+              var toggleLink = document.createElement('a');
+              toggleLink.innerText = "Toggle more links";
+              toggleLink.href = "#toggleMore";
+              toggleLink.setAttribute("class", "toggle-more-links");
+              linkCell.appendChild(toggleLink);
+            }
+            linkCell.appendChild(link);
+          });
+        });
+        document.querySelectorAll('a.toggle-more-links').forEach(function(toggleLink) {
+          toggleLink.onclick = function() {
+            var expanded = toggleLink.parentElement.getAttribute("data-more-links");
+            toggleLink.parentElement.setAttribute("data-more-links", "on" === expanded ? "off" : "on");
+            return false;
+          };
+        });
+      };
+    </script>
+  </head>
+  <body>
+    <h1>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ getCurrentTime }}</h1>
+    <table>
+    {{- range . }}
+      <tr class="group-header"><th colspan="6">{{ escapeXML .Type }}</th></tr>
+      {{- if (eq (len .Vulnerabilities) 0) }}
+      <tr><th colspan="6">No Vulnerabilities found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Package</th>
+        <th>Vulnerability ID</th>
+        <th>Severity</th>
+        <th>Installed Version</th>
+        <th>Fixed Version</th>
+        <th>Links</th>
+      </tr>
+        {{- range .Vulnerabilities }}
+      <tr class="severity-{{ escapeXML .Vulnerability.Severity }}">
+        <td class="pkg-name">{{ escapeXML .PkgName }}</td>
+        <td>{{ escapeXML .VulnerabilityID }}</td>
+        <td class="severity">{{ escapeXML .Vulnerability.Severity }}</td>
+        <td class="pkg-version">{{ escapeXML .InstalledVersion }}</td>
+        <td>{{ escapeXML .FixedVersion }}</td>
+        <td class="links" data-more-links="off">
+          {{- range .Vulnerability.References }}
+          <a href={{ escapeXML . | printf "%q" }}>{{ escapeXML . }}</a>
+          {{- end }}
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    </table>
+{{- else }}
+  </head>
+  <body>
+    <h1>Trivy Returned Empty Report</h1>
+{{- end }}
+  </body>
+</html>


### PR DESCRIPTION
I would like to start by apologizing for the fact that the PR contains several unrelated changes:

1. The image tagging is altered to a [semver](https://semver.org/)-like versioning by using the `docker/metadata-action@v3` action. This means to get a `latest` tag, we need to push a tag like `v0.1.0` to GitHub. [semver](https://semver.org/) recommends to start the initial development release at `v0.1.0`.
2. The indy_node image is now build, with a multi-stage build. This should optimize the image size and limit possible attack vectors further. Please check this carefully and give feedback. See build/Dockerfile.buster and build/Dockerfile.ubuntu18
3. The build actions have now limited caching for Docker image layers.
4. There is a `Makefile` for convenient local building.
5. The `Makefile` contains a `check_buster` and a `check_ubuntu` target, which runs a local `trivy image` check. This requires a local [trivy](https://aquasecurity.github.io/trivy/) installation.

