### PR TITLE
modified tagging schema

### DIFF
--- a/.github/workflows/build-buster.yml
+++ b/.github/workflows/build-buster.yml
@@ -39,19 +39,17 @@ jobs:
           images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/base
           tags: |
             type=raw,value=buster
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Meta for indy_node
         id: meta_indy_node
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/indy_node
-          # Note: latest will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
+          flavor: |
+            suffix=-buster
+          # Note: latest-buster will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
           tags: |
-            type=raw,value=buster
+            type=raw,value=buster,suffix=
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/.github/workflows/build-ubuntu18.yml
+++ b/.github/workflows/build-ubuntu18.yml
@@ -39,19 +39,17 @@ jobs:
           images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/base
           tags: |
             type=raw,value=ubuntu
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Meta for indy_node
         id: meta_indy_node
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ steps.repo_owner.outputs.lowercase }}/indy-node-container/indy_node
-          # Note: latest will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
+          flavor: |
+            suffix=-ubuntu
+          # Note: latest-ubuntu will be created on "git push tag" - see https://github.com/marketplace/actions/docker-metadata-action#latest-tag
           tags: |
-            type=raw,value=ubuntu
+            type=raw,value=ubuntu,suffix=
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}


### PR DESCRIPTION
Fix tagging according to #22 

The new schema looks like this

`indy_node`:`[latest | version ]`-`distro` - with distro=( buster | ubuntu )

e.g.
- indy_node:latest-buster
- indy_node:v0.1.2-buster
- indy_node:my_fancy_branch-buster
- indy_node:latest-ubuntu
- indy_node:v0.1.2-ubuntu
- indy_node:my_fancy_branch-ubuntu
