### PR TITLE
Ubuntu18 image based on Ubuntu 16 debs

### DIFF
--- a/build/Dockerfile.ubuntu18
+++ b/build/Dockerfile.ubuntu18
@@ -2,74 +2,65 @@
 # It has been created in the indy-node docker working group of the ID Union project.
 # author: Sebastian Schmittner <sebastian.schmittner@eecc.de>
 # author: Guido Wischrop <guido.wischrop@mgm-tp.com>
-# version: 1.1+2021-06-02
+# version: 1.2+2021-11-12
 
 
-# this docker file is assembled from the files in https://github.com/hyperledger/indy-node/tree/master/environment/docker/pool
+FROM ubuntu:18.04
 
-FROM ubuntu:18.04 AS base
 
 # Install environment
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
-    git \
-    wget \
-    python3.6 \
-    python3-pip \
-    python3-nacl \
     apt-transport-https \
     ca-certificates \
     software-properties-common \
-    libsodium-dev \
-    libsecp256k1-dev \
-    libssl-dev \
-    liblzma-dev \
-    libsnappy-dev \
-    liblz4-dev \
-    libbz2-dev \
-    zlib1g-dev \
-    librocksdb-dev \
-    software-properties-common \
     && apt-get autoremove -y
-RUN pip3 install -U \
-    'pip<10.0.0' \
-    # Version of setuptools needs to be pinned because support for 2to3 during builds has been removed in v58.0
-    # https://github.com/pypa/setuptools/blob/v58.0.0/CHANGES.rst
-    'setuptools<58.0'
 
-
-FROM base AS builder
-
-# deprecated dependencies based on libssl1.0 / libiny-crypto
+# get node 1.12.4 dependencies from Ubtuntu 16 + sovrin repos
 RUN \
-    # for old libssl needed for libindy-crypto
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 && \
-    add-apt-repository "deb http://security.ubuntu.com/ubuntu bionic-security main" && \
-    # for libindy-crypto
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 && \
-    add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial stable" && \
-    apt-get update && \
-    apt-get install -y libssl1.0.0 libindy-crypto=0.4.5 python3-indy-crypto=0.4.5
+    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial universe" && \
+    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial main" && \
+    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial-security main" && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 && \
+    add-apt-repository "deb https://repo.sovrin.org/deb xenial stable" 
+    
 
-RUN pip install python3-indy indy-node==1.12.4 indy-plenum==1.12.4
+RUN apt-get update -y && \
+    apt-get install -y --allow-downgrades \
+#    libssl1.0.0 \
+#    libsodium18 \
+#    libindy-crypto=0.4.5 \
+#    python3-indy-crypto=0.4.5 \
+    indy-node=1.12.4 \
+    # node depends on plenum
+    indy-plenum=1.12.4 \
+    #plenum dependencies
+    python3-ujson=1.33-1build1 \
+    python3-prompt-toolkit=0.57-1 \
+    python3-pygments=2.2.0 \
+    python3-rlp=0.5.1 \
+    python3-sha3=0.2.1 \
+    python3-leveldb=0~svn68-2build4 \
+    python3-sortedcontainers=1.5.7 \
+    python3-pip=9.0.1-2 \
+    python3-portalocker=0.5.7 \
+    python3-libnacl=1.6.1 \
+    python3-six=1.11.0 \
+    python3-intervaltree=2.1.0 \
+    python3-msgpack=0.4.6-1build1 \
+    python3-rocksdb=0.6.9 \
+    python3-dateutil=2.6.1 \
+    # meta dependencies of those python packages
+    python3-setuptools=38.5.2 \
+    python-pip-whl=9.0.1-2 \
+    # plenum in particular depends on python 3.5
+    python3=3.5.1-3 \
+    python3-minimal=3.5.1-3 \
+    libpython3-stdlib=3.5.1-3 \
+    dh-python=2.20151103ubuntu1.2 \
+    #
+    && apt-get autoremove -y
 
-FROM base
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
-            python3.6 \
-            python3-pip \
-            libsodium23 \
-            librocksdb5.8 \
-    && \
-    apt-get autoremove -y
-
-COPY --from=builder /usr/local/bin/ /usr/local/bin/
-COPY --from=builder /usr/local/lib/ /usr/local/lib/
-COPY --from=builder /usr/lib/libindy* /usr/lib/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl* /usr/lib/x86_64-linux-gnu/libcrypto* /usr/lib/x86_64-linux-gnu/
-
-RUN useradd -ms /bin/bash indy
 WORKDIR /home/indy
 
 COPY init_and_run.sh ./


### PR DESCRIPTION
Changed Ubuntu18 image to use Ubuntu 16 debs.

fixes https://github.com/IDunion/indy-node-container/issues/60


```
# apt policy libsodium18
libsodium18:
  Installed: 1.0.8-5
  Candidate: 1.0.8-5
  Version table:
 *** 1.0.8-5 500
        500 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages
        100 /var/lib/dpkg/status
```